### PR TITLE
Issue #6の対応: スクロールせず収まる2×2グリッドレイアウト

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
     .grid-container {
       display: grid;
       grid-template-columns: 2fr 1fr;
-      grid-template-rows: auto 1fr;
+      grid-template-rows: auto auto 1fr;
       gap: 20px;
       height: calc(100vh - 150px);
     }
@@ -60,8 +60,24 @@
       overflow-y: auto;
     }
 
+    /* スロットを2倍の高さに */
+    .slot-container {
+      grid-row: span 2;
+    }
+
+    /* QRコードは右上（影響なし） */
     .qr-section {
       text-align: center;
+    }
+
+    /* 履歴は最小限の高さ */
+    .history-section {
+      grid-row: 3;
+    }
+
+    /* 参加者は右下（残りの高さ） */
+    .players-section {
+      grid-row: 2 / 4;
     }
 
     .qr-section h3 {

--- a/public/index.html
+++ b/public/index.html
@@ -139,12 +139,14 @@
       background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
       color: white;
       border: none;
-      padding: 20px 60px;
+      padding: 20px 40px;
       font-size: 1.5em;
       border-radius: 50px;
       cursor: pointer;
       box-shadow: 0 4px 15px rgba(0,0,0,0.2);
       transition: transform 0.2s, box-shadow 0.2s;
+      width: fit-content;
+      margin: 0 auto;
     }
 
     .pick-button:hover {

--- a/public/index.html
+++ b/public/index.html
@@ -63,6 +63,9 @@
     /* スロットを2倍の高さに */
     .slot-container {
       grid-row: span 2;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
     }
 
     /* QRコードは右上（影響なし） */

--- a/public/index.html
+++ b/public/index.html
@@ -393,7 +393,7 @@
       width: 100%;
       height: 100%;
       background: rgba(0, 0, 0, 0.5);
-      z-index: 1998;
+      z-index: 9999;
       animation: fadeIn 0.3s ease-out;
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -304,7 +304,7 @@
       padding: 40px 60px;
       border-radius: 20px;
       box-shadow: 0 20px 60px rgba(0,0,0,0.4);
-      z-index: 2000;
+      z-index: 10000;
       text-align: center;
       animation: popupShow 0.5s ease-out forwards;
     }
@@ -319,7 +319,7 @@
       padding: 30px 50px;
       border-radius: 20px;
       box-shadow: 0 20px 60px rgba(0,0,0,0.4);
-      z-index: 2000;
+      z-index: 10000;
       text-align: center;
       animation: popupShow 0.5s ease-out forwards;
     }

--- a/public/index.html
+++ b/public/index.html
@@ -268,6 +268,9 @@
     .history-section h2 {
       color: #667eea;
       margin-bottom: 15px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
     }
 
     .history-numbers {
@@ -285,9 +288,10 @@
     }
 
     .remaining {
-      margin-top: 15px;
-      font-size: 1.2em;
+      font-size: 0.9em;
       color: #666;
+      font-weight: normal;
+    }
     }
 
     .bingo-popup {
@@ -479,9 +483,11 @@
 
       <!-- 左下: 履歴 -->
       <div class="grid-item history-section">
-        <h2>履歴</h2>
+        <h2>
+          <span>履歴</span>
+          <span class="remaining" id="remaining">残り: 75個</span>
+        </h2>
         <div class="history-numbers" id="historyNumbers"></div>
-        <div class="remaining" id="remaining">残り: 75個</div>
       </div>
 
       <!-- 右下: 参加者 -->

--- a/public/index.html
+++ b/public/index.html
@@ -295,18 +295,18 @@
     }
 
     .bingo-popup {
-      position: fixed;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%) scale(0);
+      position: fixed !important;
+      top: 50% !important;
+      left: 50% !important;
+      transform: translate(-50%, -50%) scale(0) !important;
       background: linear-gradient(135deg, #6bcf7f 0%, #4caf50 100%);
       color: white;
       padding: 40px 60px;
       border-radius: 20px;
       box-shadow: 0 20px 60px rgba(0,0,0,0.4);
-      z-index: 10000;
+      z-index: 10000 !important;
       text-align: center;
-      animation: popupShow 0.5s ease-out forwards;
+      animation: popupShow 0.5s ease-out forwards !important;
     }
 
     .reach-popup {
@@ -715,6 +715,18 @@
       // ポップアップ作成
       const popup = document.createElement('div');
       popup.className = 'bingo-popup';
+      popup.style.position = 'fixed';
+      popup.style.top = '50%';
+      popup.style.left = '50%';
+      popup.style.transform = 'translate(-50%, -50%) scale(0)';
+      popup.style.background = 'linear-gradient(135deg, #6bcf7f 0%, #4caf50 100%)';
+      popup.style.color = 'white';
+      popup.style.padding = '40px 60px';
+      popup.style.borderRadius = '20px';
+      popup.style.boxShadow = '0 20px 60px rgba(0,0,0,0.4)';
+      popup.style.zIndex = '10000';
+      popup.style.textAlign = 'center';
+      popup.style.animation = 'popupShow 0.5s ease-out forwards';
       popup.innerHTML = `
         <h2>🎉 BINGO! 🎉</h2>
         <p>${escapeHtml(playerName)} さん</p>

--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,7 @@
     }
 
     .container {
-      max-width: 1200px;
+      max-width: 1400px;
       margin: 0 auto;
       padding: 20px;
     }
@@ -34,7 +34,7 @@
     .header {
       text-align: center;
       color: white;
-      margin-bottom: 30px;
+      margin-bottom: 20px;
     }
 
     .header h1 {
@@ -43,12 +43,24 @@
       text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
     }
 
-    .qr-section {
+    /* 2×2グリッドレイアウト */
+    .grid-container {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-template-rows: auto auto;
+      gap: 20px;
+      height: calc(100vh - 150px);
+    }
+
+    .grid-item {
       background: white;
       border-radius: 15px;
       padding: 20px;
-      margin-bottom: 30px;
       box-shadow: 0 8px 16px rgba(0,0,0,0.2);
+      overflow-y: auto;
+    }
+
+    .qr-section {
       text-align: center;
     }
 
@@ -68,11 +80,6 @@
     }
 
     .slot-container {
-      background: white;
-      border-radius: 20px;
-      padding: 40px;
-      margin-bottom: 30px;
-      box-shadow: 0 10px 30px rgba(0,0,0,0.3);
       text-align: center;
     }
 
@@ -190,11 +197,6 @@
     }
 
     .players-section {
-      background: white;
-      border-radius: 15px;
-      padding: 20px;
-      margin-bottom: 30px;
-      box-shadow: 0 8px 16px rgba(0,0,0,0.2);
     }
 
     .players-section h2 {
@@ -240,10 +242,6 @@
     }
 
     .history-section {
-      background: white;
-      border-radius: 15px;
-      padding: 20px;
-      box-shadow: 0 8px 16px rgba(0,0,0,0.2);
     }
 
     .history-section h2 {
@@ -380,6 +378,12 @@
     }
 
     @media (max-width: 768px) {
+      .grid-container {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto auto auto auto;
+        height: auto;
+      }
+
       .slot-display {
         font-size: 2.5em;
         gap: 10px;
@@ -423,41 +427,47 @@
       <h1>🎉 ビンゴ数字ピック 🎉</h1>
     </div>
 
-    <div class="qr-section">
-      <h3>スマホでQRコードを読み取って参加</h3>
-      <p class="qr-trademark">※QRコードは株式会社デンソーウェーブの登録商標です。</p>
-      <div id="qrcode"></div>
-      <div id="url"></div>
-    </div>
-
-    <div class="slot-container">
-      <div class="slot-display" id="slotDisplay">
-        <span>?</span>
-        <span>?</span>
-        <span>?</span>
-        <span class="result" id="result">= ??</span>
-      </div>
-      <button class="pick-button" id="pickButton">数字をピック</button>
-      <div class="controls">
-        <div class="animation-delay-control">
-          <label for="animationDelay">アニメーション間隔:</label>
-          <input type="number" id="animationDelay" min="100" max="2000" step="100" value="500" title="100～2000msの範囲で設定できます">
-          <span>ms</span>
+    <div class="grid-container">
+      <!-- 左上: スロット -->
+      <div class="grid-item slot-container">
+        <div class="slot-display" id="slotDisplay">
+          <span>?</span>
+          <span>?</span>
+          <span>?</span>
+          <span class="result" id="result">= ??</span>
         </div>
-        <button class="control-button reset-button" id="resetButton">ゲームリセット</button>
-        <button class="control-button theme-button" id="themeButton">テーマ切替</button>
+        <button class="pick-button" id="pickButton">数字をピック</button>
+        <div class="controls">
+          <div class="animation-delay-control">
+            <label for="animationDelay">アニメーション間隔:</label>
+            <input type="number" id="animationDelay" min="100" max="2000" step="100" value="500" title="100～2000msの範囲で設定できます">
+            <span>ms</span>
+          </div>
+          <button class="control-button reset-button" id="resetButton">ゲームリセット</button>
+          <button class="control-button theme-button" id="themeButton">テーマ切替</button>
+        </div>
       </div>
-    </div>
 
-    <div class="players-section">
-      <h2>参加者 (<span id="playerCount">0</span>人)</h2>
-      <ul class="player-list" id="playerList"></ul>
-    </div>
+      <!-- 右上: QRコード -->
+      <div class="grid-item qr-section">
+        <h3>スマホでQRコードを読み取って参加</h3>
+        <p class="qr-trademark">※QRコードは株式会社デンソーウェーブの登録商標です。</p>
+        <div id="qrcode"></div>
+        <div id="url"></div>
+      </div>
 
-    <div class="history-section">
-      <h2>履歴</h2>
-      <div class="history-numbers" id="historyNumbers"></div>
-      <div class="remaining" id="remaining">残り: 75個</div>
+      <!-- 左下: 履歴 -->
+      <div class="grid-item history-section">
+        <h2>履歴</h2>
+        <div class="history-numbers" id="historyNumbers"></div>
+        <div class="remaining" id="remaining">残り: 75個</div>
+      </div>
+
+      <!-- 右下: 参加者 -->
+      <div class="grid-item players-section">
+        <h2>参加者 (<span id="playerCount">0</span>人)</h2>
+        <ul class="player-list" id="playerList"></ul>
+      </div>
     </div>
   </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
     /* 2×2グリッドレイアウト */
     .grid-container {
       display: grid;
-      grid-template-columns: 1fr 1fr;
+      grid-template-columns: 2fr 1fr;
       grid-template-rows: auto auto;
       gap: 20px;
       height: calc(100vh - 150px);

--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
     .grid-container {
       display: grid;
       grid-template-columns: 2fr 1fr;
-      grid-template-rows: auto auto 1fr;
+      grid-template-rows: auto 2fr 1fr;
       gap: 20px;
       height: calc(100vh - 150px);
     }

--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
     .grid-container {
       display: grid;
       grid-template-columns: 2fr 1fr;
-      grid-template-rows: auto auto;
+      grid-template-rows: auto 1fr;
       gap: 20px;
       height: calc(100vh - 150px);
     }


### PR DESCRIPTION
## 概要
Issue #6 に対応し、ホスト画面をスクロールなしで収まる最適化されたグリッドレイアウトに変更しました。

## レイアウト構成
```
┌─────────────┬──────┐
│             │ QR   │ ← 最小限の高さ
│  スロット    ├──────┤
│  (2倍)      │      │
│             │ 参加者│ ← 残りの高さ
├─────────────┤      │
│  履歴       │      │ ← 最小限の高さ
└─────────────┴──────┘
```

## 変更内容

### レイアウト調整
- **左右比率**: 2:1（左側が広い）
- **スロット**: 
  - 2行分の高さ（履歴の2倍）
  - 内容を垂直方向に中央配置
  - 「数字をピック」ボタンの幅を最小限に（`fit-content`）
- **QRコード**: 内容に合わせた最小限の高さ
- **履歴**: 
  - 内容に合わせた最小限の高さ
  - 「残り個数」をタイトル右側に配置（スクロールで消えない）
- **参加者**: 残りの画面高さを使用

### CSS実装
```css
.grid-container {
  display: grid;
  grid-template-columns: 2fr 1fr;
  grid-template-rows: auto 2fr 1fr;
  gap: 20px;
  height: calc(100vh - 150px);
}

.slot-container {
  grid-row: span 2;
  display: flex;
  flex-direction: column;
  justify-content: center;
}

.pick-button {
  width: fit-content;
  margin: 0 auto;
  padding: 20px 40px;
}

.history-section h2 {
  display: flex;
  justify-content: space-between;
  align-items: center;
}
```

### バグ修正
**ビンゴポップアップの表示問題**
- **症状**: ビンゴ時にポップアップが左下に表示され、背景色も表示されない
- **原因**: `.grid-item { overflow-y: auto }` が新しいスタッキングコンテキストを作成し、`position: fixed`の要素が親要素に制約されていた
- **対策**: 
  1. z-indexを2000→10000に引き上げ
  2. overlayのz-indexを1998→9999に調整
  4. **最終的にインラインスタイルで直接指定**（確実性を向上）

### レスポンシブ対応
- モバイル（768px以下）では縦積みレイアウトに自動切替
- 各セクションは独立してスクロール可能

## コミット履歴
1. 2×2グリッドレイアウトを実装
2. 左右の比率を2:1に変更
3. QRコードセクションを最低限の高さに調整
4. スロットを2倍、履歴を最小限の高さに調整
5. スロットの高さを比率で明示的に2倍に設定
6. スロット内容を中央配置に変更
7. 「数字をピック」ボタンの幅を最小限に調整
8. 残り個数を履歴タイトルの右側に配置
9. ビンゴ・リーチポップアップのz-indexを上げて表示を修正
10. overlayのz-indexを修正してポップアップ背景を正しく表示
11. ビンゴポップアップにインラインスタイルを追加（完全修正）

## CSS学習ポイント
`overflow`プロパティはスタッキングコンテキストを作成し、`position: fixed`の要素に予期しない影響を与える場合があります。今回はインラインスタイルで明示的に指定することで解決しました。

## テスト
- [x] デスクトップ表示でスクロールなし
- [x] 各セクションが適切なサイズ・配置
- [x] スロット内容が中央配置
- [x] 残り個数が常に表示
- [x] ビンゴポップアップが正しく中央表示
- [x] リーチポップアップが正しく中央表示
- [x] レスポンシブ対応（モバイルで縦積み）
- [x] 既存機能が正常動作

Closes #6

---

**Note:** This pull request was created with assistance from GitHub Copilot.